### PR TITLE
Add support for :dash keyword use-package extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## What's it
 
 This package provides an elisp interface to query and show documenation using
-[Dash](http://www.kapeli.com/dash) docsets. 
+[Dash](http://www.kapeli.com/dash) docsets.
 
 It doesn't require Dash app.
 
@@ -48,15 +48,15 @@ as explained [here](https://kapeli.com/docsets#dashdocsetfeed).
 
 ## Usage
 
-Search all currently enabled docsets (docsets in `dash-docs-docsets` or 
+Search all currently enabled docsets (docsets in `dash-docs-docsets` or
 `dash-docs-common-docsets`):
 
     (dash-docs-search "<pattern>")
-    
+
 Search a specific docset:
 
     (dash-docs-search-docset "<docset>" "<pattern>")
-    
+
 The command `dash-docs-reset-connections` will clear the connections
 to all sqlite db's. Use it in case of errors when adding new docsets.
 The next call to a search function will recreate them.
@@ -106,6 +106,42 @@ docsets sets.
 To narrow the search to just one docset, type its name in the
 beginning of the search followed by a space. If the docset contains
 spaces, no problemo, we handle it :D.
+
+### use-package integration
+
+If you are using [use-package](https://github.com/jwiegley/use-package), a :dash
+keyboard will be added to configure the `dash-docs-docsets` variable. For
+example to register the CMake dash documentation with cmake mode:
+
+``` elisp
+(use-package cmake-mode
+  :dash "CMake")
+```
+
+You can also register multiple docsets:
+``` elisp
+(use-package cmake-mode
+  :dash "CMake" "Foobar")
+```
+
+By default, dash-docs will link the docset to the package name mode hook, you
+can explicitly set the mode if it is different from the package name:
+
+``` elisp
+(use-package my-package
+  :dash (my-mode "Docset1" "Docset2"))
+```
+
+And you can register to multiple modes:
+
+``` elisp
+(use-package my-package
+  :dash (my-mode "Docset1" "Docset2")
+        (my-other-mode "Docset3"))
+```
+
+The way it works is by registering a hook to the given mode (`<mode-name>-hook`)
+and setting up `dash-docs-docsets` local variable in that hook.
 
 ## FAQ
 

--- a/dash-docs.el
+++ b/dash-docs.el
@@ -574,6 +574,9 @@ Get required params to call `dash-docs-result-url' from SEARCH-RESULT."
     (cl-loop for docset in (dash-docs-maybe-narrow-docsets pattern)
              appending (dash-docs-search-docset docset pattern))))
 
+;; Extend use package with :dash keyword if available
+(when (featurep 'use-package) (require 'use-package-dash-docs))
+
 (provide 'dash-docs)
 
 ;;; dash-docs.el ends here

--- a/use-package-dash-docs.el
+++ b/use-package-dash-docs.el
@@ -1,0 +1,74 @@
+;;; use-package-dash-docs.el --- Adds :dash keyword to use-package macro
+
+;; Copyright (C) 2019-2021 Damien Merenne
+
+;; Author: Damien Merenne <dam@cosinux.org>
+;; Created:  Sep 2018
+;; Version: 0.1
+;; Package-Requires: ((emacs "24.3") (use-package "2.4"))
+;; Keywords: convenience extensions tools
+;; URL: https://github.com/dash-docs-el/dash-docs
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 3, or (at
+;; your option) any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Commentary:
+
+;; Provides support for the :dash keyword, which is made available by
+;; default by requiring `use-package'.
+
+;;; Code:
+
+(require 'use-package-core)
+
+;;;###autoload
+(defun use-package-normalize/:dash (name-symbol keyword arg)
+  "Normalize use-package customize keyword."
+  (let ((error-msg (format  "%s :%s wants a \"docset\" definition or (\"docset\" \"docset\" ...) list or a (mode-name \"docset\" \"docset\" ...) list or a list of these." name-symbol keyword)))
+    (unless (listp arg)
+      (use-package-error error-msg))
+    (seq-map
+     (lambda (def)
+       (cond ((stringp def) (cons name-symbol arg))
+             ((listp def) (if (symbolp (car def)) def
+                            (cons name-symbol def)))
+             (t (use-package-error error-msg))))
+     arg)))
+
+;;;###autoload
+(defun use-package-handler/:dash (name keyword args rest state)
+  "Generate use-package customize keyword code."
+  (let ((body (use-package-process-keywords name rest state)))
+    (use-package-concat
+     (seq-map (lambda (def)
+                (let ((mode (intern (format "%s-hook" (car def))))
+                      (hook (intern (format "use-package-dash-setup-%s" (car def))))
+                      (docsets (cdr def)))
+                  `(progn
+                     (defun ,hook ,()
+                       (unless (boundp 'dash-docs-docsets)
+                         (setq-local dash-docs-docsets nil))
+                       (seq-do (lambda (docset)
+                                 (add-to-list 'dash-docs-docsets docset)
+                                 (dash-docs-ensure-docset-installed docset))
+                               (quote ,docsets)))
+                     (add-hook (quote ,mode) (function ,hook)))))
+              args)
+     body)))
+
+(add-to-list 'use-package-keywords :dash t)
+
+(provide 'use-package-dash-docs)
+;;; use-package-dash-docs.el ends here


### PR DESCRIPTION
This PR adds support for a :dash keyword in use-package so that when using it, you can do a

``` elisp
(use-package cmake-mode
  :dash (cmake-mode "CMake"))
```