### PR TITLE
Fixed extraction error when tar does not throw an error.

### DIFF
--- a/dash-docs.el
+++ b/dash-docs.el
@@ -340,7 +340,7 @@ If doesn't exist, it asks to create it."
     (let* ((call-process-args (list "tar" nil t nil))
 	   (process-args (list
 			  "xfv" docset-temp-path
-			  "-C" dash-docs-docsets-path))
+			  "-C" (dash-docs-docsets-path)))
 	   ;; On Windows, several elements need to be removed from filenames, see
 	   ;; https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#naming-conventions.
 	   ;; We replace with underscores on windows. This might lead to broken links.

--- a/dash-docs.el
+++ b/dash-docs.el
@@ -351,7 +351,7 @@ If doesn't exist, it asks to create it."
       (cond
        ((and (not (equal result 0))
 	     ;; TODO: Adjust to proper text. Also requires correct locale.
-	     (search-backward "too long"))
+	     (search-backward "too long" nil t))
 	(error "Failed to extract %s to %s. Filename too long. Consider changing `dash-docs-docsets-path' to a shorter value" docset-temp-path (dash-docs-docsets-path)))
        ((not (equal result 0)) (error "Failed to extract %s to %s. Error: %s" docset-temp-path (dash-docs-docsets-path) result)))
       (goto-char (point-max))


### PR DESCRIPTION
Added the 'no-error' argument to `search-backward` so it doesn't throw when no errors occur during tar extraction.