### PR TITLE
Prevent sqlite3 warning output

### DIFF
--- a/dash-docs.el
+++ b/dash-docs.el
@@ -147,7 +147,7 @@ If there are errors, print them in `dash-docs-debugging-buffer'"
                          (make-temp-file "dash-docs-errors-file"))))
        (call-process "sqlite3" nil (list standard-output error-file) nil
                      ;; args for sqlite3:
-                     "-list" "-init" "''" db-path sql)
+                     "-list" "-init" null-device db-path sql)
 
        ;; display errors, stolen from emacs' `shell-command` function
        (when (and error-file (file-exists-p error-file))


### PR DESCRIPTION
Hi. When using sqlite3 version 3.34.1 I get the following output in the `*dash-docs-errors*` buffer:

```
----------------
 HEY! This is dash-docs (sqlite) error logging. If you want to disable it, set `dash-docs-enable-debugging` to nil
---------------- 


cannot open: "''"

cannot open: "''"

cannot open: "''"

cannot open: "''"

``` 
This PR fixes this behavior by using `null-device` (`"/dev/null"` when using linux) instead of `''` for the `-init` argument of sqlite3.
