### PR TITLE
Expand path selected in install-docset-from-file

### DIFF
--- a/dash-docs.el
+++ b/dash-docs.el
@@ -339,7 +339,7 @@ If doesn't exist, it asks to create it."
   (with-temp-buffer
     (let* ((call-process-args (list "tar" nil t nil))
 	   (process-args (list
-			  "xfv" docset-temp-path
+			  "xfv" (expand-file-name docset-temp-path)
 			  "-C" (dash-docs-docsets-path)))
 	   ;; On Windows, several elements need to be removed from filenames, see
 	   ;; https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#naming-conventions.


### PR DESCRIPTION
For example, `~/C.tgz` is not recognized by `tar`.