### PR TITLE
Avoid "cannot open" messages

### DIFF
--- a/dash-docs.el
+++ b/dash-docs.el
@@ -147,7 +147,7 @@ If there are errors, print them in `dash-docs-debugging-buffer'"
        (apply
         'call-process "sqlite3" nil (list standard-output error-file) nil
                       ;; args for sqlite3:
-                      (dash-docs-get-sqlite3-args db-path sql))
+                      (dash-docs-get-sqlite-args db-path sql))
 
        ;; display errors, stolen from emacs' `shell-command` function
        (when (and error-file (file-exists-p error-file))
@@ -165,7 +165,7 @@ If there are errors, print them in `dash-docs-debugging-buffer'"
                (display-buffer (current-buffer))))
          (delete-file error-file))))))
 
-(defun dash-docs-get-sqlite3-args (db-path sql)
+(defun dash-docs-get-sqlite-args (db-path sql)
   "Return SQLite args to run the SQL command in the db at DB-PATH.
 
 These args depend on the SQLite version and the OS version used.
@@ -176,29 +176,29 @@ These args depend on the SQLite version and the OS version used.
   ;; '' doesn't exist and you need to pass the null device instead. For those
   ;; versions, you also have to provide argument "-batch" to avoid the output of
   ;; status information.
-  (if (version< dash-docs-sqlite3-version "3.34.0")
+  (if (version< dash-docs-sqlite-version "3.34.0")
       `("-list" "-init" "''" ,db-path ,sql)
     (let ((null-device (if (eq system-type 'windows-nt) "nul" "/dev/null")))
       `("-list" "-init" ,null-device "-batch" ,db-path ,sql))))
 
-(defun dash-docs-extract-sqlite3-version (sqlite3-version-output)
-  "Extract the SQLite version from SQLITE3-VERSION-OUTPUT.
-SQLITE3-VERSION-OUTPUT is the output of a call to \"sqlite3
+(defun dash-docs-extract-sqlite-version (sqlite-version-output)
+  "Extract the SQLite version from SQLITE-VERSION-OUTPUT.
+SQLITE-VERSION-OUTPUT is the output of a call to \"sqlite3
 --version\" as a list of strings. If this function cannot parse
 that output, it returns \"0.0.0\", which serves as the (fake)
 oldest version of SQLite."
-  (let ((oldest-sqlite3-version "0.0.0"))
-    (if (>= (length sqlite3-version-output) 1)
-        (let ((sqlite3-version-string (car sqlite3-version-output)))
+  (let ((oldest-sqlite-version "0.0.0"))
+    (if (>= (length sqlite-version-output) 1)
+        (let ((sqlite-version-string (car sqlite-version-output)))
           (if (string-match
                "^\\([[:digit:]]+[.][[:digit:]]+[.][[:digit:]]+\\) [[:digit:]]\\{4\\}-"
-               sqlite3-version-string)
-              (match-string 1 sqlite3-version-string)
-            oldest-sqlite3-version))
-      oldest-sqlite3-version)))
+               sqlite-version-string)
+              (match-string 1 sqlite-version-string)
+            oldest-sqlite-version))
+      oldest-sqlite-version)))
 
-(defvar dash-docs-sqlite3-version
-  (dash-docs-extract-sqlite3-version (process-lines "sqlite3" "--version"))
+(defvar dash-docs-sqlite-version
+  (dash-docs-extract-sqlite-version (process-lines "sqlite3" "--version"))
   "Version of available sqlite3 binary.
 This version string is retrieved by executing \"sqlite3
 --version\" and parsing its output.")

--- a/dash-docs.el
+++ b/dash-docs.el
@@ -145,9 +145,10 @@ If there are errors, print them in `dash-docs-debugging-buffer'"
    (with-output-to-string
      (let ((error-file (when dash-docs-enable-debugging
                          (make-temp-file "dash-docs-errors-file"))))
-       (call-process "sqlite3" nil (list standard-output error-file) nil
-                     ;; args for sqlite3:
-                     "-list" "-init" "''" db-path sql)
+       (apply
+        'call-process "sqlite3" nil (list standard-output error-file) nil
+                      ;; args for sqlite3:
+                      (dash-docs-get-sqlite3-args db-path sql))
 
        ;; display errors, stolen from emacs' `shell-command` function
        (when (and error-file (file-exists-p error-file))
@@ -164,6 +165,9 @@ If there are errors, print them in `dash-docs-debugging-buffer'"
                  (goto-char (- (point-max) pos-from-end)))
                (display-buffer (current-buffer))))
          (delete-file error-file))))))
+
+(defun dash-docs-get-sqlite3-args (db-path sql &rest sqlite3-version)
+  `("-list" "-init" "''" ,db-path ,sql))
 
 (defun dash-docs-parse-sql-results (sql-result-string)
   "Parse SQL-RESULT-STRING splitting it by newline and '|' chars."

--- a/dash-docs.el
+++ b/dash-docs.el
@@ -168,7 +168,8 @@ If there are errors, print them in `dash-docs-debugging-buffer'"
 (defun dash-docs-get-sqlite3-args (db-path sql)
   (if (version< dash-docs-sqlite3-version "3.34.0")
       `("-list" "-init" "''" ,db-path ,sql)
-    `("-list" "-init" "/dev/null" "-batch" ,db-path ,sql)))
+    (let ((null-device (if (eq system-type 'windows-nt) "nul" "/dev/null")))
+      `("-list" "-init" ,null-device "-batch" ,db-path ,sql))))
 
 (defun dash-docs-extract-sqlite3-version (sqlite3-version-output)
   (let ((oldest-sqlite3-version "0.0.0"))

--- a/dash-docs.el
+++ b/dash-docs.el
@@ -168,7 +168,7 @@ If there are errors, print them in `dash-docs-debugging-buffer'"
 (defun dash-docs-get-sqlite-args (db-path sql)
   "Return SQLite args to run the SQL command in the db at DB-PATH.
 
-These args depend on the SQLite version and the OS version used.
+These args depend on the SQLite version.
 "
   ;; To avoid any initialization when SQLite runs the command, use the init
   ;; option. For SQLite versions older than 3.34.0, you would use arguments
@@ -178,8 +178,7 @@ These args depend on the SQLite version and the OS version used.
   ;; status information.
   (if (version< dash-docs-sqlite-version "3.34.0")
       `("-list" "-init" "''" ,db-path ,sql)
-    (let ((null-device (if (eq system-type 'windows-nt) "nul" "/dev/null")))
-      `("-list" "-init" ,null-device "-batch" ,db-path ,sql))))
+    `("-list" "-init" ,null-device "-batch" ,db-path ,sql)))
 
 (defun dash-docs-extract-sqlite-version (sqlite-version-output)
   "Extract the SQLite version from SQLITE-VERSION-OUTPUT.

--- a/test/dash-docs-test.el
+++ b/test/dash-docs-test.el
@@ -174,9 +174,14 @@
       (should (equal '("-list" "-init" "''" "/path/to/db" "SELECT ...") actual-result)))))
 
 (ert-deftest dash-docs-sqlite3-args-with-newer-version-uses-different-init()
-  (let ((dash-docs-sqlite3-version "3.34.0"))
+  (let ((dash-docs-sqlite3-version "3.34.0") (system-type 'linux))
     (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
       (should (equal '("-list" "-init" "/dev/null" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
+
+(ert-deftest dash-docs-sqlite3-args-with-newer-version-uses-different-init()
+  (let ((dash-docs-sqlite3-version "3.34.0") (system-type 'windows-nt))
+    (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
+      (should (equal '("-list" "-init" "nul" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
 
 (ert-deftest dash-docs-extract-sqlite3-version-using-valid-output()
   (let ((dash-docs-sqlite3-version "3.34.0"))

--- a/test/dash-docs-test.el
+++ b/test/dash-docs-test.el
@@ -174,14 +174,15 @@
       (should (equal '("-list" "-init" "''" "/path/to/db" "SELECT ...") actual-result)))))
 
 (ert-deftest dash-docs-sqlite-args-with-newer-version-uses-different-init()
-  (let ((dash-docs-sqlite-version "3.34.0") (system-type 'linux))
+  (let ((dash-docs-sqlite-version "3.34.0") (null-device "/dev/null"))
     (let ((actual-result (dash-docs-get-sqlite-args "/path/to/db" "SELECT ...")))
       (should (equal '("-list" "-init" "/dev/null" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
 
-(ert-deftest dash-docs-sqlite-args-with-newer-version-uses-different-init()
-  (let ((dash-docs-sqlite-version "3.34.0") (system-type 'windows-nt))
+(ert-deftest dash-docs-sqlite-args-with-newer-version-uses-different-init-and-null-device()
+  ;; null-device "NUL" is used by Windows
+  (let ((dash-docs-sqlite-version "3.34.0") (null-device "NUL"))
     (let ((actual-result (dash-docs-get-sqlite-args "/path/to/db" "SELECT ...")))
-      (should (equal '("-list" "-init" "nul" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
+      (should (equal '("-list" "-init" "NUL" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
 
 (ert-deftest dash-docs-extract-sqlite-version-using-valid-output()
   (let ((dash-docs-sqlite-version "3.34.0"))

--- a/test/dash-docs-test.el
+++ b/test/dash-docs-test.el
@@ -168,8 +168,23 @@
 
 ;;;; dash-docs-get-sqlite3-args
 
-(ert-deftest dash-docs-sqlite3-args-without-version-is-backward-compatible ()
-  (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
-    (should (equal '("-list" "-init" "''" "/path/to/db" "SELECT ...") actual-result))))
+(ert-deftest dash-docs-sqlite3-args-with-old-version-is-backward-compatible()
+  (let ((dash-docs-sqlite3-version "3.33.0"))
+    (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
+      (should (equal '("-list" "-init" "''" "/path/to/db" "SELECT ...") actual-result)))))
+
+(ert-deftest dash-docs-sqlite3-args-with-newer-version-uses-different-init()
+  (let ((dash-docs-sqlite3-version "3.34.0"))
+    (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
+      (should (equal '("-list" "-init" "/dev/null" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
+
+(ert-deftest dash-docs-extract-sqlite3-version-using-valid-output()
+  (let ((dash-docs-sqlite3-version "3.34.0"))
+    (let ((sqlite3-version-output '("3.34.0 2020-12-01 16:14:00 a26b6597e3ae272231b96f9982c3bcc17ddec2f2b6eb4df06a224b91089fed5b")))
+      (should (equal "3.34.0" (dash-docs-extract-sqlite3-version sqlite3-version-output))))))
+
+(ert-deftest dash-docs-extract-sqlite3-version-using-empty-output()
+  (let ((sqlite3-version-output ()))
+    (should (equal "0.0.0" (dash-docs-extract-sqlite3-version sqlite3-version-output)))))
 
 ;;; dash-docs-test ends here

--- a/test/dash-docs-test.el
+++ b/test/dash-docs-test.el
@@ -166,30 +166,30 @@
 
 (provide 'dash-docs-test)
 
-;;;; dash-docs-get-sqlite3-args
+;;;; dash-docs-get-sqlite-args
 
-(ert-deftest dash-docs-sqlite3-args-with-old-version-is-backward-compatible()
-  (let ((dash-docs-sqlite3-version "3.33.0"))
-    (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
+(ert-deftest dash-docs-sqlite-args-with-old-version-is-backward-compatible()
+  (let ((dash-docs-sqlite-version "3.33.0"))
+    (let ((actual-result (dash-docs-get-sqlite-args "/path/to/db" "SELECT ...")))
       (should (equal '("-list" "-init" "''" "/path/to/db" "SELECT ...") actual-result)))))
 
-(ert-deftest dash-docs-sqlite3-args-with-newer-version-uses-different-init()
-  (let ((dash-docs-sqlite3-version "3.34.0") (system-type 'linux))
-    (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
+(ert-deftest dash-docs-sqlite-args-with-newer-version-uses-different-init()
+  (let ((dash-docs-sqlite-version "3.34.0") (system-type 'linux))
+    (let ((actual-result (dash-docs-get-sqlite-args "/path/to/db" "SELECT ...")))
       (should (equal '("-list" "-init" "/dev/null" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
 
-(ert-deftest dash-docs-sqlite3-args-with-newer-version-uses-different-init()
-  (let ((dash-docs-sqlite3-version "3.34.0") (system-type 'windows-nt))
-    (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
+(ert-deftest dash-docs-sqlite-args-with-newer-version-uses-different-init()
+  (let ((dash-docs-sqlite-version "3.34.0") (system-type 'windows-nt))
+    (let ((actual-result (dash-docs-get-sqlite-args "/path/to/db" "SELECT ...")))
       (should (equal '("-list" "-init" "nul" "-batch" "/path/to/db" "SELECT ...") actual-result)))))
 
-(ert-deftest dash-docs-extract-sqlite3-version-using-valid-output()
-  (let ((dash-docs-sqlite3-version "3.34.0"))
-    (let ((sqlite3-version-output '("3.34.0 2020-12-01 16:14:00 a26b6597e3ae272231b96f9982c3bcc17ddec2f2b6eb4df06a224b91089fed5b")))
-      (should (equal "3.34.0" (dash-docs-extract-sqlite3-version sqlite3-version-output))))))
+(ert-deftest dash-docs-extract-sqlite-version-using-valid-output()
+  (let ((dash-docs-sqlite-version "3.34.0"))
+    (let ((sqlite-version-output '("3.34.0 2020-12-01 16:14:00 a26b6597e3ae272231b96f9982c3bcc17ddec2f2b6eb4df06a224b91089fed5b")))
+      (should (equal "3.34.0" (dash-docs-extract-sqlite-version sqlite-version-output))))))
 
-(ert-deftest dash-docs-extract-sqlite3-version-using-empty-output()
-  (let ((sqlite3-version-output ()))
-    (should (equal "0.0.0" (dash-docs-extract-sqlite3-version sqlite3-version-output)))))
+(ert-deftest dash-docs-extract-sqlite-version-using-empty-output()
+  (let ((sqlite-version-output ()))
+    (should (equal "0.0.0" (dash-docs-extract-sqlite-version sqlite-version-output)))))
 
 ;;; dash-docs-test ends here

--- a/test/dash-docs-test.el
+++ b/test/dash-docs-test.el
@@ -166,4 +166,10 @@
 
 (provide 'dash-docs-test)
 
+;;;; dash-docs-get-sqlite3-args
+
+(ert-deftest dash-docs-sqlite3-args-without-version-is-backward-compatible ()
+  (let ((actual-result (dash-docs-get-sqlite3-args "/path/to/db" "SELECT ...")))
+    (should (equal '("-list" "-init" "''" "/path/to/db" "SELECT ...") actual-result))))
+
 ;;; dash-docs-test ends here


### PR DESCRIPTION
This pull request addresses ticket #17 , that reports that the user sees many `cannot open: "''"` messages.

This issue is caused by a change in SQLite. To avoid any initialization when SQLite runs a command, dash-docs calls SQlite with the `-init` option. For SQLite versions older than 3.34.0, you would use arguments `-init ""`. As of that version, SQLite reports the error that file `'"` doesn't exist and you need to pass the null device instead.

This pull request checks the SQLite version in-use and provides the appropriate version of the arguments.